### PR TITLE
Fix offer creation JSON enum issue

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -53,7 +53,11 @@ builder.Services.AddScoped<IOfferService, OfferService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {


### PR DESCRIPTION
## Summary
- ensure APIs interpret enums like `Currency` from string values

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fd2945b8832d8f6baa51831dd7d0