### PR TITLE
Add product and customer tables with CRUD

### DIFF
--- a/Controllers/CustomersController.cs
+++ b/Controllers/CustomersController.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OfferManagement.API.DTOs;
+using OfferManagement.API.Services;
+
+namespace OfferManagement.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class CustomersController : ControllerBase
+{
+    private readonly ICustomerService _customerService;
+
+    public CustomersController(ICustomerService customerService)
+    {
+        _customerService = customerService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetCustomers()
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var customers = await _customerService.GetCustomersByCompanyAsync(companyId);
+        return Ok(customers);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetCustomer(int id)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var customer = await _customerService.GetCustomerByIdAsync(id, companyId);
+        if (customer == null)
+        {
+            return NotFound("Customer not found");
+        }
+
+        return Ok(customer);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateCustomer([FromBody] CreateCustomerRequest request)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var customer = await _customerService.CreateCustomerAsync(request, companyId);
+        return CreatedAtAction(nameof(GetCustomer), new { id = customer.Id }, customer);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateCustomer(int id, [FromBody] UpdateCustomerRequest request)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var customer = await _customerService.UpdateCustomerAsync(id, request, companyId);
+        if (customer == null)
+        {
+            return NotFound("Customer not found");
+        }
+
+        return Ok(customer);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteCustomer(int id)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var success = await _customerService.DeleteCustomerAsync(id, companyId);
+        if (!success)
+        {
+            return NotFound("Customer not found");
+        }
+
+        return Ok(new { Success = true, Message = "Customer deleted successfully" });
+    }
+}

--- a/Controllers/ProductsController.cs
+++ b/Controllers/ProductsController.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OfferManagement.API.DTOs;
+using OfferManagement.API.Services;
+
+namespace OfferManagement.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class ProductsController : ControllerBase
+{
+    private readonly IProductService _productService;
+
+    public ProductsController(IProductService productService)
+    {
+        _productService = productService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetProducts()
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var products = await _productService.GetProductsByCompanyAsync(companyId);
+        return Ok(products);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetProduct(int id)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var product = await _productService.GetProductByIdAsync(id, companyId);
+        if (product == null)
+        {
+            return NotFound("Product not found");
+        }
+
+        return Ok(product);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateProduct([FromBody] CreateProductRequest request)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var product = await _productService.CreateProductAsync(request, companyId);
+        return CreatedAtAction(nameof(GetProduct), new { id = product.Id }, product);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateProduct(int id, [FromBody] UpdateProductRequest request)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var product = await _productService.UpdateProductAsync(id, request, companyId);
+        if (product == null)
+        {
+            return NotFound("Product not found");
+        }
+
+        return Ok(product);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteProduct(int id)
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var success = await _productService.DeleteProductAsync(id, companyId);
+        if (!success)
+        {
+            return NotFound("Product not found");
+        }
+
+        return Ok(new { Success = true, Message = "Product deleted successfully" });
+    }
+}

--- a/DTOs/CustomerDTOs.cs
+++ b/DTOs/CustomerDTOs.cs
@@ -1,0 +1,26 @@
+namespace OfferManagement.API.DTOs;
+
+public class CustomerDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Phone { get; set; }
+    public string? Address { get; set; }
+}
+
+public class CreateCustomerRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Phone { get; set; }
+    public string? Address { get; set; }
+}
+
+public class UpdateCustomerRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Phone { get; set; }
+    public string? Address { get; set; }
+}

--- a/DTOs/ProductDTOs.cs
+++ b/DTOs/ProductDTOs.cs
@@ -1,0 +1,26 @@
+namespace OfferManagement.API.DTOs;
+
+public class ProductDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Category { get; set; }
+    public decimal Price { get; set; }
+}
+
+public class CreateProductRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Category { get; set; }
+    public decimal Price { get; set; }
+}
+
+public class UpdateProductRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string? Category { get; set; }
+    public decimal Price { get; set; }
+}

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -13,6 +13,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<Company> Companies { get; set; }
     public DbSet<Offer> Offers { get; set; }
     public DbSet<OfferItem> OfferItems { get; set; }
+    public DbSet<Product> Products { get; set; }
+    public DbSet<Customer> Customers { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -75,6 +77,36 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             entity.HasOne(oi => oi.Offer)
                   .WithMany(o => o.Items)
                   .HasForeignKey(oi => oi.OfferId)
+                  .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // Product configuration
+        builder.Entity<Product>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.Description).HasMaxLength(1000);
+            entity.Property(e => e.Category).HasMaxLength(100);
+            entity.Property(e => e.Price).HasColumnType("decimal(18,2)");
+
+            entity.HasOne(p => p.Company)
+                  .WithMany(c => c.Products)
+                  .HasForeignKey(p => p.CompanyId)
+                  .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // Customer configuration
+        builder.Entity<Customer>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Name).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.Email).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.Phone).HasMaxLength(20);
+            entity.Property(e => e.Address).HasMaxLength(500);
+
+            entity.HasOne(cu => cu.Company)
+                  .WithMany(c => c.Customers)
+                  .HasForeignKey(cu => cu.CompanyId)
                   .OnDelete(DeleteBehavior.Cascade);
         });
     }

--- a/Migrations/20250712000000_AddProductsAndCustomers.Designer.cs
+++ b/Migrations/20250712000000_AddProductsAndCustomers.Designer.cs
@@ -11,9 +11,11 @@ using OfferManagement.API.Data;
 namespace OfferManagement.API.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250712000000_AddProductsAndCustomers")]
+    partial class AddProductsAndCustomers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250712000000_AddProductsAndCustomers.cs
+++ b/Migrations/20250712000000_AddProductsAndCustomers.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OfferManagement.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProductsAndCustomers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Customers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Phone = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true),
+                    Address = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    CompanyId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Customers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Customers_Companies_CompanyId",
+                        column: x => x.CompanyId,
+                        principalTable: "Companies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Products",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: true),
+                    Category = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    Price = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    CompanyId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Products", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Products_Companies_CompanyId",
+                        column: x => x.CompanyId,
+                        principalTable: "Companies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Customers_CompanyId",
+                table: "Customers",
+                column: "CompanyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_CompanyId",
+                table: "Products",
+                column: "CompanyId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Customers");
+
+            migrationBuilder.DropTable(
+                name: "Products");
+        }
+    }
+}

--- a/Models/Company.cs
+++ b/Models/Company.cs
@@ -37,8 +37,12 @@ public class Company
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     
     public ICollection<ApplicationUser> Users { get; set; } = new List<ApplicationUser>();
-    
+
     public ICollection<Offer> Offers { get; set; } = new List<Offer>();
+
+    public ICollection<Product> Products { get; set; } = new List<Product>();
+
+    public ICollection<Customer> Customers { get; set; } = new List<Customer>();
 }
 
 public enum SubscriptionPlan

--- a/Models/Customer.cs
+++ b/Models/Customer.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OfferManagement.API.Models;
+
+public class Customer
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public string Email { get; set; } = string.Empty;
+
+    public string? Phone { get; set; }
+
+    public string? Address { get; set; }
+
+    public int CompanyId { get; set; }
+
+    public Company Company { get; set; } = null!;
+}

--- a/Models/Product.cs
+++ b/Models/Product.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OfferManagement.API.Models;
+
+public class Product
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public string? Category { get; set; }
+
+    public decimal Price { get; set; }
+
+    public int CompanyId { get; set; }
+
+    public Company Company { get; set; } = null!;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -52,6 +52,8 @@ builder.Services.AddScoped<ICompanyService, CompanyService>();
 builder.Services.AddScoped<IOfferService, OfferService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IEmailService, EmailService>();
+builder.Services.AddScoped<IProductService, ProductService>();
+builder.Services.AddScoped<ICustomerService, CustomerService>();
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>

--- a/Services/CustomerService.cs
+++ b/Services/CustomerService.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using OfferManagement.API.Data;
+using OfferManagement.API.DTOs;
+using OfferManagement.API.Models;
+
+namespace OfferManagement.API.Services;
+
+public class CustomerService : ICustomerService
+{
+    private readonly ApplicationDbContext _context;
+
+    public CustomerService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<CustomerDto>> GetCustomersByCompanyAsync(int companyId)
+    {
+        var customers = await _context.Customers
+            .Where(c => c.CompanyId == companyId)
+            .ToListAsync();
+
+        return customers.Select(MapToDto).ToList();
+    }
+
+    public async Task<CustomerDto?> GetCustomerByIdAsync(int id, int companyId)
+    {
+        var customer = await _context.Customers
+            .FirstOrDefaultAsync(c => c.Id == id && c.CompanyId == companyId);
+
+        return customer == null ? null : MapToDto(customer);
+    }
+
+    public async Task<CustomerDto> CreateCustomerAsync(CreateCustomerRequest request, int companyId)
+    {
+        var customer = new Customer
+        {
+            Name = request.Name,
+            Email = request.Email,
+            Phone = request.Phone,
+            Address = request.Address,
+            CompanyId = companyId
+        };
+
+        _context.Customers.Add(customer);
+        await _context.SaveChangesAsync();
+
+        return MapToDto(customer);
+    }
+
+    public async Task<CustomerDto?> UpdateCustomerAsync(int id, UpdateCustomerRequest request, int companyId)
+    {
+        var customer = await _context.Customers
+            .FirstOrDefaultAsync(c => c.Id == id && c.CompanyId == companyId);
+
+        if (customer == null) return null;
+
+        customer.Name = request.Name;
+        customer.Email = request.Email;
+        customer.Phone = request.Phone;
+        customer.Address = request.Address;
+
+        await _context.SaveChangesAsync();
+
+        return MapToDto(customer);
+    }
+
+    public async Task<bool> DeleteCustomerAsync(int id, int companyId)
+    {
+        var customer = await _context.Customers
+            .FirstOrDefaultAsync(c => c.Id == id && c.CompanyId == companyId);
+
+        if (customer == null) return false;
+
+        _context.Customers.Remove(customer);
+        await _context.SaveChangesAsync();
+        return true;
+    }
+
+    private static CustomerDto MapToDto(Customer customer)
+    {
+        return new CustomerDto
+        {
+            Id = customer.Id,
+            Name = customer.Name,
+            Email = customer.Email,
+            Phone = customer.Phone,
+            Address = customer.Address
+        };
+    }
+}

--- a/Services/ICustomerService.cs
+++ b/Services/ICustomerService.cs
@@ -1,0 +1,12 @@
+using OfferManagement.API.DTOs;
+
+namespace OfferManagement.API.Services;
+
+public interface ICustomerService
+{
+    Task<List<CustomerDto>> GetCustomersByCompanyAsync(int companyId);
+    Task<CustomerDto?> GetCustomerByIdAsync(int id, int companyId);
+    Task<CustomerDto> CreateCustomerAsync(CreateCustomerRequest request, int companyId);
+    Task<CustomerDto?> UpdateCustomerAsync(int id, UpdateCustomerRequest request, int companyId);
+    Task<bool> DeleteCustomerAsync(int id, int companyId);
+}

--- a/Services/IProductService.cs
+++ b/Services/IProductService.cs
@@ -1,0 +1,12 @@
+using OfferManagement.API.DTOs;
+
+namespace OfferManagement.API.Services;
+
+public interface IProductService
+{
+    Task<List<ProductDto>> GetProductsByCompanyAsync(int companyId);
+    Task<ProductDto?> GetProductByIdAsync(int id, int companyId);
+    Task<ProductDto> CreateProductAsync(CreateProductRequest request, int companyId);
+    Task<ProductDto?> UpdateProductAsync(int id, UpdateProductRequest request, int companyId);
+    Task<bool> DeleteProductAsync(int id, int companyId);
+}

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using OfferManagement.API.Data;
+using OfferManagement.API.DTOs;
+using OfferManagement.API.Models;
+
+namespace OfferManagement.API.Services;
+
+public class ProductService : IProductService
+{
+    private readonly ApplicationDbContext _context;
+
+    public ProductService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<ProductDto>> GetProductsByCompanyAsync(int companyId)
+    {
+        var products = await _context.Products
+            .Where(p => p.CompanyId == companyId)
+            .ToListAsync();
+
+        return products.Select(MapToDto).ToList();
+    }
+
+    public async Task<ProductDto?> GetProductByIdAsync(int id, int companyId)
+    {
+        var product = await _context.Products
+            .FirstOrDefaultAsync(p => p.Id == id && p.CompanyId == companyId);
+
+        return product == null ? null : MapToDto(product);
+    }
+
+    public async Task<ProductDto> CreateProductAsync(CreateProductRequest request, int companyId)
+    {
+        var product = new Product
+        {
+            Name = request.Name,
+            Description = request.Description,
+            Category = request.Category,
+            Price = request.Price,
+            CompanyId = companyId
+        };
+
+        _context.Products.Add(product);
+        await _context.SaveChangesAsync();
+
+        return MapToDto(product);
+    }
+
+    public async Task<ProductDto?> UpdateProductAsync(int id, UpdateProductRequest request, int companyId)
+    {
+        var product = await _context.Products
+            .FirstOrDefaultAsync(p => p.Id == id && p.CompanyId == companyId);
+
+        if (product == null) return null;
+
+        product.Name = request.Name;
+        product.Description = request.Description;
+        product.Category = request.Category;
+        product.Price = request.Price;
+
+        await _context.SaveChangesAsync();
+
+        return MapToDto(product);
+    }
+
+    public async Task<bool> DeleteProductAsync(int id, int companyId)
+    {
+        var product = await _context.Products
+            .FirstOrDefaultAsync(p => p.Id == id && p.CompanyId == companyId);
+
+        if (product == null) return false;
+
+        _context.Products.Remove(product);
+        await _context.SaveChangesAsync();
+        return true;
+    }
+
+    private static ProductDto MapToDto(Product product)
+    {
+        return new ProductDto
+        {
+            Id = product.Id,
+            Name = product.Name,
+            Description = product.Description,
+            Category = product.Category,
+            Price = product.Price
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add models for `Product` and `Customer`
- expand `Company` with `Products` and `Customers` collections
- update `ApplicationDbContext` with new DbSets and entity configuration
- create DTOs, services and controllers for products and customers
- register the new services
- include migration `AddProductsAndCustomers`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723bfff5a8832d8436e05f31eb3d37