### PR TITLE
Record payment on plan upgrade and add history endpoint

### DIFF
--- a/Controllers/CompanyController.cs
+++ b/Controllers/CompanyController.cs
@@ -85,7 +85,7 @@ public class CompanyController : ControllerBase
             return BadRequest("Invalid company");
         }
 
-        var company = await _companyService.UpgradePlanAsync(companyId, request.Plan);
+        var company = await _companyService.UpgradePlanAsync(companyId, request);
         if (company == null)
         {
             return NotFound("Company not found");
@@ -110,5 +110,18 @@ public class CompanyController : ControllerBase
         }
 
         return Ok(payment);
+    }
+
+    [HttpGet("payments")]
+    public async Task<IActionResult> GetPaymentHistory()
+    {
+        var companyIdClaim = User.FindFirst("CompanyId")?.Value;
+        if (companyIdClaim == null || !int.TryParse(companyIdClaim, out var companyId))
+        {
+            return BadRequest("Invalid company");
+        }
+
+        var payments = await _companyService.GetPaymentHistoryAsync(companyId);
+        return Ok(payments);
     }
 }

--- a/DTOs/SubscriptionDTOs.cs
+++ b/DTOs/SubscriptionDTOs.cs
@@ -5,4 +5,6 @@ namespace OfferManagement.API.DTOs;
 public class UpgradePlanRequest
 {
     public SubscriptionPlan Plan { get; set; }
+    public decimal Amount { get; set; }
+    public string? TransactionId { get; set; }
 }

--- a/Services/ICompanyService.cs
+++ b/Services/ICompanyService.cs
@@ -9,6 +9,7 @@ public interface ICompanyService
     Task<CompanyDto?> GetCompanyByUserIdAsync(string userId);
     Task<CompanyDto?> UpdateCompanyAsync(int id, UpdateCompanyRequest request);
     Task<bool> UploadLogoAsync(int id, IFormFile logo);
-    Task<CompanyDto?> UpgradePlanAsync(int id, SubscriptionPlan plan);
+    Task<CompanyDto?> UpgradePlanAsync(int id, UpgradePlanRequest request);
     Task<PaymentDto?> RecordPaymentAsync(int id, RecordPaymentRequest request);
+    Task<List<PaymentDto>> GetPaymentHistoryAsync(int id);
 }


### PR DESCRIPTION
## Summary
- capture payment info during plan upgrade
- extend upgrade request DTO with payment details
- implement payment history retrieval for companies
- expose new endpoint to fetch payment history

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e79f5bd0832d91a02a8b6c5c99cc