### PR TITLE
Add super admin dashboard

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OfferManagement.API.DTOs;
+using OfferManagement.API.Services;
+
+namespace OfferManagement.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Roles = "SuperAdmin")]
+public class AdminController : ControllerBase
+{
+    private readonly IAdminService _adminService;
+
+    public AdminController(IAdminService adminService)
+    {
+        _adminService = adminService;
+    }
+
+    [HttpGet("dashboard")]
+    public async Task<IActionResult> GetDashboard()
+    {
+        var dashboard = await _adminService.GetDashboardAsync();
+        return Ok(dashboard);
+    }
+
+    [HttpPost("companies/{id}/upgrade")]
+    public async Task<IActionResult> UpgradeCompany(int id, [FromBody] UpgradePlanRequest request)
+    {
+        var company = await _adminService.UpgradeCompanyAsync(id, request);
+        if (company == null)
+        {
+            return NotFound("Company not found");
+        }
+        return Ok(company);
+    }
+}

--- a/DTOs/AdminDTOs.cs
+++ b/DTOs/AdminDTOs.cs
@@ -1,0 +1,24 @@
+namespace OfferManagement.API.DTOs;
+
+using OfferManagement.API.Models;
+
+public class CompanySummaryDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int OfferCount { get; set; }
+    public int UserCount { get; set; }
+    public SubscriptionPlan SubscriptionPlan { get; set; }
+}
+
+public class AdminDashboardDto
+{
+    public List<CompanySummaryDto> Companies { get; set; } = new();
+    public int TotalCompanies { get; set; }
+    public int ProCompanies { get; set; }
+    public int FreeCompanies { get; set; }
+    public decimal RevenueToday { get; set; }
+    public decimal RevenueThisWeek { get; set; }
+    public decimal RevenueThisMonth { get; set; }
+    public decimal RevenueTotal { get; set; }
+}

--- a/Services/AdminService.cs
+++ b/Services/AdminService.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore;
+using OfferManagement.API.Data;
+using OfferManagement.API.DTOs;
+using OfferManagement.API.Models;
+
+namespace OfferManagement.API.Services;
+
+public class AdminService : IAdminService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ICompanyService _companyService;
+
+    public AdminService(ApplicationDbContext context, ICompanyService companyService)
+    {
+        _context = context;
+        _companyService = companyService;
+    }
+
+    public async Task<AdminDashboardDto> GetDashboardAsync()
+    {
+        var companies = await _context.Companies
+            .Include(c => c.Users)
+            .Include(c => c.Offers)
+            .ToListAsync();
+
+        var companySummaries = companies.Select(c => new CompanySummaryDto
+        {
+            Id = c.Id,
+            Name = c.Name,
+            OfferCount = c.Offers.Count,
+            UserCount = c.Users.Count,
+            SubscriptionPlan = c.SubscriptionPlan
+        }).ToList();
+
+        var totalCompanies = companies.Count;
+        var proCompanies = companies.Count(c => c.SubscriptionPlan == SubscriptionPlan.Pro);
+        var freeCompanies = companies.Count(c => c.SubscriptionPlan == SubscriptionPlan.Free);
+
+        var today = DateTime.UtcNow.Date;
+        var startOfWeek = today.AddDays(-(int)today.DayOfWeek);
+        var startOfMonth = new DateTime(today.Year, today.Month, 1);
+
+        var payments = await _context.Payments.ToListAsync();
+        var revenueToday = payments.Where(p => p.PaidAt.Date == today).Sum(p => p.Amount);
+        var revenueWeek = payments.Where(p => p.PaidAt.Date >= startOfWeek).Sum(p => p.Amount);
+        var revenueMonth = payments.Where(p => p.PaidAt.Date >= startOfMonth).Sum(p => p.Amount);
+        var revenueTotal = payments.Sum(p => p.Amount);
+
+        return new AdminDashboardDto
+        {
+            Companies = companySummaries,
+            TotalCompanies = totalCompanies,
+            ProCompanies = proCompanies,
+            FreeCompanies = freeCompanies,
+            RevenueToday = revenueToday,
+            RevenueThisWeek = revenueWeek,
+            RevenueThisMonth = revenueMonth,
+            RevenueTotal = revenueTotal
+        };
+    }
+
+    public async Task<CompanyDto?> UpgradeCompanyAsync(int companyId, UpgradePlanRequest request)
+    {
+        return await _companyService.UpgradePlanAsync(companyId, request);
+    }
+}

--- a/Services/IAdminService.cs
+++ b/Services/IAdminService.cs
@@ -1,0 +1,9 @@
+using OfferManagement.API.DTOs;
+
+namespace OfferManagement.API.Services;
+
+public interface IAdminService
+{
+    Task<AdminDashboardDto> GetDashboardAsync();
+    Task<CompanyDto?> UpgradeCompanyAsync(int companyId, UpgradePlanRequest request);
+}


### PR DESCRIPTION
## Summary
- create DTOs for admin dashboard data
- implement AdminService for aggregating company info and revenue
- expose new AdminController requiring `SuperAdmin` role
- register AdminService and create `SuperAdmin` role with optional default user

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fbde0a14832d95becb2bc27a04ad